### PR TITLE
Fix validator stake to show self-delegation instead of total tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,19 @@ make install
 ### Manual Installation
 
 ```bash
-# Prerequisites: Python 3.8+, pocketd CLI
+# Prerequisites: Python 3.8+, pipx, pocketd CLI
 
-# Clone repository
+# Install pipx if you don't have it
+brew install pipx  # macOS
+# or: pip install pipx
+
+# Clone and install
 git clone https://github.com/buildwithgrove/pocket-knife.git
 cd pocket-knife
-
-# Install with pipx (recommended)
 pipx install .
 
 # Or install in development mode
-pip install -e .
+pipx install -e .
 ```
 
 ## Keyring Backends

--- a/docs/treasury.md
+++ b/docs/treasury.md
@@ -91,13 +91,13 @@ Query liquid + staked balances for nodes/suppliers:
 ```
 
 ### Validator Stakes
-Query liquid + staked + commission:
+Query liquid + self-stake + commission:
 ```json
 {
   "validator_stakes": ["poktvaloper1..."]
 }
 ```
-**Note:** Use validator operator addresses (`poktvaloper1...`), not consensus addresses. Commission represents validator operator earnings from all delegations.
+**Note:** Use validator operator addresses (`poktvaloper1...`), not consensus addresses. Shows the validator's **self-delegation** (their own stake), not total tokens bonded. This prevents double-counting when delegators are tracked separately. Commission represents validator operator earnings.
 
 ### Delegator Stakes
 Query liquid + delegated stake + rewards:
@@ -208,7 +208,7 @@ pocketknife treasury --file treasury.json --max-workers 3
 **Liquid:** Direct balance query
 **App Stakes:** Liquid + application stake
 **Node Stakes:** Liquid + supplier stake
-**Validator Stakes:** Liquid + validator stake + commission
+**Validator Stakes:** Liquid + self-stake + commission
 **Delegator Stakes:** Liquid + delegated stake + rewards
 
 ### Duplicate Detection


### PR DESCRIPTION
## Summary

- Changed validator stake query from total tokens to **self-delegation only**
- This prevents double-counting when delegators are tracked separately in the treasury config
- Updated table header from "Staked" to "Self-Stake" for clarity
- Updated README to recommend `pipx` for installation
- Updated treasury docs to clarify self-stake terminology

## Problem

Previously, the validator stake query used `pocketd query staking validator` which returns **total tokens** bonded to the validator (including all external delegators). When a delegator wallet was also tracked in the config, the same stake was counted twice.

Example:
- Validator total tokens: 2,015,000 POKT
- Delegator delegation: 2,000,000 POKT
- **Old total:** 4,015,000 POKT (wrong - double counted)
- **New total:** 2,015,000 POKT (correct)

## Solution

Now queries `pocketd query staking delegation <account> <operator>` to get only the validator's self-delegation, not total tokens bonded.

## Test plan

- [x] Run `pk-grove` and verify validator shows self-stake (15,000 POKT) not total tokens
- [x] Verify delegator shows delegation (2,000,000 POKT) separately
- [x] Confirm no double-counting in treasury total

🤖 Generated with [Claude Code](https://claude.com/claude-code)