### PR TITLE
fix: update mainnet RPC endpoint to pocket.api.pocket.network

### DIFF
--- a/pocketknife/cli.py
+++ b/pocketknife/cli.py
@@ -138,7 +138,7 @@ def add_services(
     # Validate network and set node URL and chain ID
     network_config = {
         "main": {
-            "node_url": "https://shannon-grove-rpc.mainnet.poktroll.com",
+            "node_url": "https://api.pocket.network",
             "chain_id": "pocket"
         },
         "beta": {
@@ -2210,7 +2210,7 @@ def get_node_stake_balance(address: str) -> tuple[float, float, bool, str]:
     # Get staked balance
     cmd = [
         "pocketd", "query", "supplier", "show-supplier", address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
     
@@ -2269,7 +2269,7 @@ def get_app_stake_balance(address: str) -> tuple[float, float, bool, str]:
     # Get staked balance
     cmd = [
         "pocketd", "query", "application", "show-application", address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
     
@@ -2324,7 +2324,7 @@ def get_liquid_balance(address: str) -> tuple[float, bool, str]:
     """
     cmd = [
         "pocketd", "query", "bank", "balances", address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
     
@@ -2391,7 +2391,7 @@ def get_delegator_rewards(account_address: str) -> tuple[float, bool, str]:
     """
     cmd = [
         "pocketd", "query", "distribution", "rewards", account_address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
     
@@ -2439,7 +2439,7 @@ def get_delegated_amount(account_address: str) -> tuple[float, bool, str]:
     """
     cmd = [
         "pocketd", "query", "staking", "delegations", account_address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
 
@@ -2508,7 +2508,7 @@ def get_validator_commission(validator_operator_address: str) -> tuple[float, bo
     """
     cmd = [
         "pocketd", "query", "distribution", "commission", validator_operator_address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
     
@@ -2577,7 +2577,7 @@ def get_validator_stake_balance(address: str) -> tuple[float, float, float, bool
     # Query the delegation from the validator's account address to their operator address
     cmd = [
         "pocketd", "query", "staking", "delegation", account_address, address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--output", "json"
     ]
 
@@ -3497,7 +3497,7 @@ def fetch_suppliers_for_owner(owner_address: str) -> list[str]:
     cmd = [
         "pocketd", "q", "supplier", "list-suppliers",
         "--owner-address", owner_address,
-        "--node", "https://shannon-grove-rpc.mainnet.poktroll.com",
+        "--node", "https://api.pocket.network",
         "--grpc-insecure=false",
         "-o", "json",
         "--page-limit=100000",

--- a/pocketknife/cli.py
+++ b/pocketknife/cli.py
@@ -138,7 +138,7 @@ def add_services(
     # Validate network and set node URL and chain ID
     network_config = {
         "main": {
-            "node_url": "https://api.pocket.network",
+            "node_url": "https://pocket.api.pocket.network",
             "chain_id": "pocket"
         },
         "beta": {
@@ -2210,7 +2210,7 @@ def get_node_stake_balance(address: str) -> tuple[float, float, bool, str]:
     # Get staked balance
     cmd = [
         "pocketd", "query", "supplier", "show-supplier", address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
     
@@ -2269,7 +2269,7 @@ def get_app_stake_balance(address: str) -> tuple[float, float, bool, str]:
     # Get staked balance
     cmd = [
         "pocketd", "query", "application", "show-application", address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
     
@@ -2324,7 +2324,7 @@ def get_liquid_balance(address: str) -> tuple[float, bool, str]:
     """
     cmd = [
         "pocketd", "query", "bank", "balances", address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
     
@@ -2391,7 +2391,7 @@ def get_delegator_rewards(account_address: str) -> tuple[float, bool, str]:
     """
     cmd = [
         "pocketd", "query", "distribution", "rewards", account_address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
     
@@ -2439,7 +2439,7 @@ def get_delegated_amount(account_address: str) -> tuple[float, bool, str]:
     """
     cmd = [
         "pocketd", "query", "staking", "delegations", account_address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
 
@@ -2508,7 +2508,7 @@ def get_validator_commission(validator_operator_address: str) -> tuple[float, bo
     """
     cmd = [
         "pocketd", "query", "distribution", "commission", validator_operator_address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
     
@@ -2577,7 +2577,7 @@ def get_validator_stake_balance(address: str) -> tuple[float, float, float, bool
     # Query the delegation from the validator's account address to their operator address
     cmd = [
         "pocketd", "query", "staking", "delegation", account_address, address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--output", "json"
     ]
 
@@ -3497,7 +3497,7 @@ def fetch_suppliers_for_owner(owner_address: str) -> list[str]:
     cmd = [
         "pocketd", "q", "supplier", "list-suppliers",
         "--owner-address", owner_address,
-        "--node", "https://api.pocket.network",
+        "--node", "https://pocket.api.pocket.network",
         "--grpc-insecure=false",
         "-o", "json",
         "--page-limit=100000",


### PR DESCRIPTION
## Summary

- `shannon-grove-rpc.mainnet.poktroll.com` is no longer reachable
- Replaces all 9 hardcoded occurrences of the old mainnet RPC URL with the current canonical CometBFT RPC endpoint at `pocket.api.pocket.network`
- Beta endpoint (`shannon-testnet-grove-rpc.beta.poktroll.com`) left unchanged — open to updating if there's a new canonical beta URL

## Test plan

- [ ] `pocketknife treasury` commands resolve against `pocket.api.pocket.network`
- [ ] `pocketknife fetch-suppliers main` works against the new endpoint
- [ ] All other commands that previously hardcoded the old node URL now route correctly